### PR TITLE
Add overflow scroll to ensure table not cutoff

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,7 @@
 html, body {
   width: 400px;
   height: 600px;
+  overflow: scroll;
 }
 
 p {


### PR DESCRIPTION
- Perhaps a race condition with the two places of saving
- But any way added this to address an issue I saw in some edge cases 

before: 

https://github.com/wapopartners/Fusion-Browser-Extension/issues/20#issuecomment-837277119

after: 

<img width="1146" alt="Screen Shot 2021-05-10 at 15 39 10" src="https://user-images.githubusercontent.com/5950956/117721852-fa2e7180-b1a5-11eb-940e-c487ace4084f.png">
