### PR TITLE
Remove logging that shows in non-fusion pages as well

### DIFF
--- a/public/content.js
+++ b/public/content.js
@@ -54,6 +54,18 @@ function saveFusionData(fusionData) {
   sendAndSaveObject({ globalContent });
 }
 
+chrome.tabs.query({ active: true, lastFocusedWindow: true }, (tabs) => {
+  const url = tabs[0].url;
+  if (url.indexOf('localhost') > -1) {
+    let receivedData = false;
+    setTimeout(() => {
+      if (!receivedData) {
+        console.log('Fusion Browser Extension: Did not receive data');
+      }
+    }, 1000);
+  }
+});
+
 const processFusionEvent = (event) => {
   // todo: this seems to be re-running multiple times in console
   // console.log('event listener added in content.js')

--- a/public/content.js
+++ b/public/content.js
@@ -54,13 +54,10 @@ function saveFusionData(fusionData) {
   sendAndSaveObject({ globalContent });
 }
 
-let receivedData = false;
-
 const processFusionEvent = (event) => {
   // todo: this seems to be re-running multiple times in console
   // console.log('event listener added in content.js')
   if (event.data.type === 'engine-msg') {
-    receivedData = true;
     chrome.storage.sync.set({ data: true });
     saveFusionData(event.data);
   }

--- a/public/content.js
+++ b/public/content.js
@@ -55,11 +55,6 @@ function saveFusionData(fusionData) {
 }
 
 let receivedData = false;
-setTimeout(() => {
-  if (!receivedData) {
-    console.log('Fusion Browser Extension: Did not receive data');
-  }
-}, 1000);
 
 const processFusionEvent = (event) => {
   // todo: this seems to be re-running multiple times in console

--- a/public/content.js
+++ b/public/content.js
@@ -54,22 +54,20 @@ function saveFusionData(fusionData) {
   sendAndSaveObject({ globalContent });
 }
 
-chrome.tabs.query({ active: true, lastFocusedWindow: true }, (tabs) => {
-  const url = tabs[0].url;
-  if (url.indexOf('localhost') > -1) {
-    let receivedData = false;
-    setTimeout(() => {
-      if (!receivedData) {
-        console.log('Fusion Browser Extension: Did not receive data');
-      }
-    }, 1000);
-  }
-});
+// For devs debugging, uncomment below to see if the browser is working as expected. Make sure to uncomment below as well the received data being true if working.
+// let receivedData = false;
+// setTimeout(() => {
+//   if (!receivedData) {
+//     console.log('Fusion Browser Extension: Did not receive data');
+//   }
+// }, 1000);
 
 const processFusionEvent = (event) => {
   // todo: this seems to be re-running multiple times in console
   // console.log('event listener added in content.js')
   if (event.data.type === 'engine-msg') {
+    // If debugging received data, uncomment below
+    // receivedData = true;
     chrome.storage.sync.set({ data: true });
     saveFusionData(event.data);
   }

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -29,5 +29,7 @@
       "run_at": "document_end"
     }
   ],
-  "permissions": ["storage", "tabs"]
+  "permissions": [
+    "storage"
+  ]
 }

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -29,7 +29,5 @@
       "run_at": "document_end"
     }
   ],
-  "permissions": [
-    "storage"
-  ]
+  "permissions": ["storage", "tabs"]
 }


### PR DESCRIPTION
Noticed this is showing up in the published version. Hope it's a small thing to build and redeploy 

shows up on all pages 

<img width="725" alt="Screen Shot 2022-06-09 at 17 04 38" src="https://user-images.githubusercontent.com/5950956/172953017-d710f06f-ed44-43da-bc29-95fcffa4639f.png">

